### PR TITLE
Add 'proleptic_gregorian' calendar

### DIFF
--- a/definitions/dimensions.json
+++ b/definitions/dimensions.json
@@ -61,6 +61,7 @@
       "360_day"
     ],
     "calenders_other": [
+      "proleptic_gregorian",
       "360_day"
     ]
   },


### PR DESCRIPTION
This calendar is needed for the monthly files of the WaterGAP water (global) models. They expect monthly files created from 31-day months ('proleptic gregorian' calendar).